### PR TITLE
[14.0][IMP][account-financial-reporting]: filter by due date

### DIFF
--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -108,12 +108,17 @@
         <div class="act_as_table data_table" style="width: 100%;">
             <div class="act_as_row labels">
                 <div class="act_as_cell">Date at filter</div>
+                <div class="act_as_cell">Due Date at filter</div>
                 <div class="act_as_cell">Target moves filter</div>
                 <div class="act_as_cell">Account balance at 0 filter</div>
+                <div class="act_as_cell">Sort mode</div>
             </div>
             <div class="act_as_row">
                 <div class="act_as_cell">
                     <span t-esc="date_at" />
+                </div>
+                <div class="act_as_cell">
+                    <span t-esc="due_date_at" />
                 </div>
                 <div class="act_as_cell">
                     <t t-if="target_move == 'posted'">All posted entries</t>
@@ -122,6 +127,11 @@
                 <div class="act_as_cell">
                     <t t-if="hide_account_at_0">Hide</t>
                     <t t-if="not hide_account_at_0">Show</t>
+                </div>
+                <div class="act_as_cell">
+                    <span
+                        t-esc="{'invoice_date': 'Invoice Date', 'due_date': 'Due Date'}.get(sort_report_type)"
+                    />
                 </div>
             </div>
         </div>

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -15,6 +15,14 @@ class OpenItemsReportWizard(models.TransientModel):
 
     date_at = fields.Date(required=True, default=fields.Date.context_today)
     date_from = fields.Date(string="Date From")
+    due_date_from = fields.Date(string="Date From")
+    due_date_at = fields.Date(string="At")
+    sort_report_type = fields.Selection(
+        [("invoice_date", "Invoice Date"), ("due_date", "Due Date")],
+        string="Sort By",
+        required=True,
+        default="invoice_date",
+    )
     target_move = fields.Selection(
         [("posted", "All Posted Entries"), ("all", "All Entries")],
         string="Target Moves",
@@ -154,6 +162,7 @@ class OpenItemsReportWizard(models.TransientModel):
 
     def _prepare_report_open_items(self):
         self.ensure_one()
+
         return {
             "wizard_id": self.id,
             "date_at": fields.Date.to_string(self.date_at),
@@ -167,6 +176,11 @@ class OpenItemsReportWizard(models.TransientModel):
             "account_ids": self.account_ids.ids,
             "partner_ids": self.partner_ids.ids or [],
             "account_financial_report_lang": self.env.lang,
+            "due_date_at": fields.Date.to_string(self.due_date_at),
+            "due_date_from": fields.Date.to_string(self.due_date_from)
+            if self.due_date_from
+            else False,
+            "sort_report_type": self.sort_report_type,
         }
 
     def _export(self, report_type):

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -14,17 +14,24 @@
                     />
                 </group>
                 <group name="filters">
-                    <group name="date_range">
-                        <field name="date_at" />
-                        <field name="date_from" />
+                    <group name="date_range" col="1">
+                            <group name="emission_date" string="Emission" col="3">
+                                <field name="date_at" />
+                                <field name="date_from" />
+                            </group>
+                            <group name="due_date" string="Maturity" col="3">
+                                <field name="due_date_from" />
+                                <field name="due_date_at" />
+                            </group>
+                        </group>
+                        <group name="other_filters">
+                            <field name="target_move" widget="radio" />
+                            <field name="show_partner_details" />
+                            <field name="hide_account_at_0" />
+                            <field name="foreign_currency" />
+                            <field name="sort_report_type" />
+                        </group>
                     </group>
-                    <group name="other_filters">
-                        <field name="target_move" widget="radio" />
-                        <field name="show_partner_details" />
-                        <field name="hide_account_at_0" />
-                        <field name="foreign_currency" />
-                    </group>
-                </group>
                 <group name="partner_filter" col="1">
                     <label for="partner_ids" />
                     <field
@@ -68,21 +75,15 @@
                         type="object"
                         default_focus="1"
                         class="oe_highlight"
-                    />
-                    or
-                    <button
+                    /> or <button
                         name="button_export_pdf"
                         string="Export PDF"
                         type="object"
-                    />
-                    or
-                    <button
+                    /> or <button
                         name="button_export_xlsx"
                         string="Export XLSX"
                         type="object"
-                    />
-                    or
-                    <button string="Cancel" class="oe_link" special="cancel" />
+                    /> or <button string="Cancel" class="oe_link" special="cancel" />
                 </footer>
             </form>
         </field>
@@ -94,7 +95,8 @@
         <field name="view_id" ref="open_items_wizard" />
         <field name="target">new</field>
     </record>
-    <!--Add to res.partner action-->
+    <!--Add
+    to res.partner action-->
     <record
         id="act_action_open_items_wizard_partner_relation"
         model="ir.actions.act_window"


### PR DESCRIPTION
## Alteração para personalização dos relatórios 
Adicionando os campos `due_date_from` e `due_date_at` para usuário para filtrar data de vencimento inicial e limite e um campo selection `sort_report_type` para escolher o modo de ordenação do relatório podendo ser por: data de vencimento ou data de lançamento da fatura.
Essa alteração deixa mais personalizáveis para o usuário para fazer seus relatórios.

![wizardtestenovo2](https://github.com/Engenere/account-financial-reporting/assets/142639425/d5788570-450e-440c-9ed7-85962a73c28d)

Demostração de como ficaria o wizard com os campos adicionados. 

O relatório que foi configurado no wizard com a escolha de ordena por data de lançamento da fatura ficaria assim: 
 
![wizardNovo](https://github.com/Engenere/account-financial-reporting/assets/142639425/f9e77d7c-61b0-40d0-92b2-7ca486010a12)




